### PR TITLE
Make trivial considered an internal change

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -7,6 +7,7 @@
     "major": "Version: Major",
     "minor": "Version: Minor",
     "patch": "Version: Patch",
-  },
-  "skipReleaseLabels": ["Version: Trivial", "Skip Release"]
+    "internal": "Version: Trivial",
+    "skip-release": "Skip Release"
+  }
 }


### PR DESCRIPTION
The idea is to have changes marked as trivial still show up in the changelog. 